### PR TITLE
Block 743550 * Next Difficulty Adjustment = 743903

### DIFF
--- a/Tracker/charts/bitinfo/04072022.md
+++ b/Tracker/charts/bitinfo/04072022.md
@@ -1,0 +1,93 @@
+#  ₿itcoin ⚡ Timechain Summary
+(sum of all currently existing Bitcoin)	19,084,291 BTC
+
+### Market Capitalization ~  $364 Billion
+(market value of all currently existing Bitcoin)	$364,641,120,908
+
+### Timestamp⌛(2022-07-04 01:14:34) ₿itcoin Price
+###   1 BTC = 19,111.88 USD
+
+- ftx: 19,109 USD (2022-07-04 01:15:02)
+- coinbasepro: 19,106.89 USD (2022-07-04 00:44:46)
+- coinsbit: 19,136.87 USD (2022-07-04 01:14:01)
+- bitfinex: 19,129 USD (2022-07-04 01:15:01)
+- kraken: 19,111.5 USD (2022-07-04 01:15:02)
+###  ...FIAT/BTC...
+- 1 USD = 0.000052 BTC
+- 1 EUR = 0.000055 BTC
+- 1 RUB = 0.00000095 BTC
+- 1 JPY = 0.00000039 BTC
+- 1 USDT = 0.000052 BTC
+- 1 BRZ = 0.0000098 BTC
+
+### Transactions last 24h
+(Number of transactions in blockchain per day)	~ 204,194
+
+### Transactions avg. per hour	8,508
+Bitcoins sent last 24h	~ 2,354,591 BTC ($44,988,872,977) 12.34% market cap
+
+Bitcoins sent avg. per hour (last 24h)	~ 98,108 BTC ($1,874,536,374)
+
+Avg. Transaction Value ~	11.53 BTC ($220,324)
+
+Median Transaction Value ~	0.023 BTC ($437.84)
+
+### Avg. Transaction Fee ~	0.000049 BTC ($0.929) 0.00000014 BTC/byte
+
+Median Transaction Fee ~	0.000017 BTC ($0.326)
+
+# Block Time ⏳
+### (average time between blocks)	8m 47s  🕘
+
+Blocks Count ~	743,550 (2022-07-04 01:12:06)
+
+Block Size ~	463.076 KBytes
+
+Blocks last 24h	~ 164
+
+Blocks avg. per hour (last 24h) ~	7
+
+Reward Per Block ~	6.25+0.06 BTC ($120,564.46) 
+
+### Next halving @ block 840000 (in 96450 blocks ~ 652 days)
+
+Reward (last 24h)	1,025+9.84 BTC ($19,772,571.93)
+
+Fee in Reward
+(Average Fee Percentage in Total Block Reward)	1.02%
+
+# Difficulty	29.57 T next retarget @ block 743904 
+# (in 354 blocks ~ 2 days 9 hours)
+
+### Hashrate	220.297 Ehash/s +13.44% in 24 hours
+
+Bitcoin Mining Profitability	0.0898 USD/Day for 1 THash/s
+
+Top 100 Richest	2,952,602 BTC ($56,414,993,397) 15.47% Total
+
+### Wealth Distribution
+Top 10/100/1,000/10,000 addesses	6.22% / 15.47% / 34.18% / 58.37% Total
+
+Addresses richer than
+1/100/1,000/10,000 USD	34,621,842 / 13,052,270 / 4,922,727 / 1,312,686
+
+Active Addresses last 24h
+(Number of unique (from or to) addresses per day)	644,568
+
+100 Largest Transactions	last 24h: 753,571 BTC ($14,398,393,526) 32.00% Total
+
+# First Block 🔳
+(Bitcoin creation date)	2009-01-09
+
+### Blockchain Size 💽
+(Bitcoin database size)	480.25 GB
+
+Reddit subscribers	4,363,997
+
+Tweets per day #Bitcoin	108,361
+
+# Github release	v23.0 (2022-04-25)
+
+### Github stars	65050
+
+### Github last commit	2022-07-01


### PR DESCRIPTION
Timestamp - Block 743550   ($19111.09 USD)   
 
353 blocks to re-target 
 
Next Adjustment Date:   06 July 2022  03:30:09 ET  @ Block 743903
 
Difficulty is a value used to show how hard is it to find a hash that will be lower than target defined by system.  The Bitcoin network has a global block difficulty.  Valid blocks must have a hash below this target.  Mining pools also have a pool-specific share difficulty setting a lower limit for shares.
 
The difficulty is adjusted every 2016 blocks based on the time it took to find the previous 2016 blocks.  At the desired rate of one block each 10 minutes, 2016 blocks would take exactly two weeks to find.  If the previous 2016 blocks took more than two weeks to find, the difficulty is reduced.  If they took less than two weeks, the difficulty is increased.  The change in difficulty is in proportion to the amount of time over or under two weeks the previous 2016 blocks took to find.  To find a block, the hash must be less than the target.  The hash is effectively a random number between 0 and 2**256-1.


"As computers get faster and the total computing power applied to creating bitcoin increases, the difficulty increases proportionally to keep the total new production constant. Thus, it is known in advance how many new bitcoins will be created every year in the future."