### PR TITLE
Timestamp: ₿lock 747397 ⌛ JULY 31, 2022

### DIFF
--- a/Bitinfo/BTC/20220731.md
+++ b/Bitinfo/BTC/20220731.md
@@ -1,0 +1,82 @@
+# Timestamp ⚡ Bitcoin ( JULY 31, 2022 ) 丰 Stats and Info
+(total sum of all currently existing Bitcoin)	= 19,108,325 BTC
+
+### Market Capitalization
+(market value of all currently existing Bitcoin)	= $452,640,520,313
+
+Bitcoin Price  (1 bitcoin = 1 bitcoin)
+
+     1 BTC = 23,688.13 USD (2022-07-31 15:01:13)
+
+- ftx: 23,885 USD (2022-07-31 15:10:02)
+- coinsbit: 23,908.7 USD (2022-07-31 15:07:01)
+- coinbasepro: 23,460.65 USD (2022-07-31 14:36:47)
+- bitfinex: 23,890.77 USD (2022-07-31 15:09:01)
+- kraken: 23,890.4 USD (2022-07-31 15:10:01)
+
+...fiat/btc...
+
+- 1 USD = 0.000042 BTC
+- 1 EUR = 0.000043 BTC
+- 1 RUB = 0.00000067 BTC
+- 1 JPY = 0.00000031 BTC
+- 1 USDT = 0.000042 BTC
+- 1 BRZ = 0.000008 BTC
+
+# Block Count	747,397 (2022-07-31 15:02:12)
+
+Block Size	= 620.89 KBytes
+
+Blocks last 24h	= 143
+
+Blocks avg. per hour (last 24h)	= 6
+
+Reward Per Block	= 6.25+0.07998 BTC ($149,945.45) 
+
+### Next halving @ block 840000 (in 92603 blocks ~ 628 days)
+
+Reward (last 24h)	= 893.75+11.44 BTC ($21,442,198.65)
+
+Fee in Reward (Average Fee Percentage in Total Block Reward)	= 1.52%
+
+# Next retarget @ block 747936 (in 539 blocks ~ 3 days 15 hours)
+### Difficulty	27.693 T
+    Hashrate	183.074 Ehash/s -7.34% in 24 hours
+
+Bitcoin Mining Profitability	0.1171 USD/Day for 1 THash/s
+
+Transactions last 24h (Number of transactions in blockchain per day)	= 218,174
+
+Transactions avg. per hour	= 9,091
+
+Bitcoins sent last 24h	= 1,244,504 BTC ($29,479,967,590) 6.51% market cap
+
+Bitcoins sent avg. per hour (last 24h)	= 51,854 BTC ($1,228,331,983)
+
+Avg. Transaction Value	= 5.70 BTC ($135,121)
+
+Median Transaction Value	= 0.019 BTC ($449.57)
+
+  ### Avg. Transaction Fee	= 0.000054 BTC ($1.29) 0.00000016 BTC/byte
+
+    Median Transaction Fee	= 0.000021 BTC ($0.502)
+
+Block Time (average time between blocks)	= 10m 0s
+
+# First Block
+(Bitcoin creation date)	2009-01-09
+
+Timechain Size (Bitcoin database size)	485.52 GB
+
+Reddit subscribers	= 4,444,141
+
+Tweets per day #Bitcoin	= 114,699
+
+# Github release	v23.0 (2022-04-25)
+
+### Github stars	65489
+
+### Github last commit	2022-07-30
+Homepage	https://bitcoin.org/
+
+💙💜


### PR DESCRIPTION
 Block Count	747,397 (2022-07-31 15:02:12)

Avg. Transaction Fee	= 0.000054 BTC ($1.29) 0.00000016 BTC/byte

Next retarget @ block 747936 (in 539 blocks ~ 3 days 15 hours)