### PR TITLE
Timestamp: ₿lock 750389 ⌛ AUG 21, 2022

### DIFF
--- a/Bitinfo/BTC/20220821.md
+++ b/Bitinfo/BTC/20220821.md
@@ -1,0 +1,77 @@
+# Timestamp ⚡ Bitcoin ( AUGUST 21, 2022 ) 丰 Stats
+
+### Blocks Count	750,389 (2022-08-21 00:00:44)
+     19,127,015 BTC = Total sum of all currently existing Bitcoin 
+     $405,114,884,427 = Market Capitalization
+
+### Bitcoin Price  ( 1 bitcoin = 1 bitcoin )
+	1 BTC = 21,180.25 USD (2022-08-21 00:07:25)
+- ftx: 21,198 USD (2022-08-21 00:05:03)
+- coinbasepro: 21,183.7 USD (2022-08-20 23:56:46)
+- coinsbit: 21,194.62 USD (2022-08-21 00:07:02)
+- bitfinex: 21,199 USD (2022-08-21 00:09:01)
+- kraken: 21,198.4 USD (2022-08-21 00:10:01)
+
+...FIAT/BTC...
+
+- 1 USD = 0.000047 BTC
+- 1 EUR = 0.000047 BTC
+- 1 RUB = 0.00000079 BTC
+- 1 JPY = 0.00000034 BTC
+- 1 USDT = 0.000047 BTC
+- 1 BRZ = 0.000009 BTC
+
+Block Time (average time between blocks)	~  9m 32s
+
+Block Size	= 536.035 KBytes
+
+Blocks last 24h	= 151
+
+Blocks avg. per hour (last 24h)	= 6
+
+### Reward Per Block	= 6.25+0.05734 BTC ($133,591) 
+    Next halving @ block 840000 (in 89611 blocks ~ 610 days)
+
+Reward (last 24h)	= 943.75+8.66 BTC ($20,172,241.72)
+
+Fee in Reward (Average Fee Percentage in Total Block Reward)	0.96%
+
+# Next retarget @ block 751968 (in 1579 blocks ~ 10 days 15 hours)
+    Hashrate	 233.701 Ehash/s (-0.93% in 24 hours)
+    Difficulty	 28.352 T 
+    
+Bitcoin Mining Profitability	= 0.0863 USD/Day for 1 THash/s
+
+Transactions last 24h (Number of transactions in blockchain per day)	= 225,252
+
+Transactions avg. per hour	= 9,386
+
+Bitcoins sent last 24h	= 3,421,362 BTC ($72,465,295,933) 17.89% market cap
+
+Bitcoins sent avg. per hour (last 24h)	= 142,557 BTC ($3,019,387,331)
+
+Avg. Transaction Value	= 15.19 BTC ($321,708)
+
+Median Transaction Value	= 0.02 BTC ($422.5)
+
+### Avg. Transaction Fee	= 0.000041 BTC ($0.86) 0.00000011 BTC/byte
+    Median Transaction Fee	= 0.000014 BTC ($0.296)
+
+# First Block
+(Bitcoin creation date)	2009-01-09
+
+Timechain 🪩 Size (Bitcoin database size)	489.56 GB
+
+Reddit subscribers	~ 4,499,018
+
+Tweets per day #Bitcoin	~ 108,997
+
+# Github release	v23.0 (2022-04-25)
+
+### Github stars	65796
+
+### Github last commit	2022-08-20
+
+Homepage	https://bitcoin.org/
+
+💙💜


### PR DESCRIPTION
Block Count	750,389   ( 2022-08-21 00:00:44 )

Reward Per Block	=  6.25+0.05734 BTC   ($133,591)

Avg. Transaction Fee	0.000041 BTC   ($0.86)   0.00000011 BTC/byte

Hashrate 	233.701 Ehash/s   ( -0.93% in 24 hours )

Difficulty	28.352 T 

Next retarget @ block 751968   ( in 1579 blocks ~ 10 days 15 hours )